### PR TITLE
Version 0.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: flake8-async CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools tox
+        python -m tox --notest --recreate -e check
+    - name: Run checks
+      run: |
+        python -m tox -e check
+        git diff --exit-code
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools tox
+        python -m tox --notest --recreate -e test
+    - name: Run tests
+      run: python -m tox -e test -- -n auto
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [check, test]
+    if: github.repository == 'cooperlees/flake8-async' &&  github.ref == 'refs/heads/main'
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v1
+      with:
+        python-version: "3.10"
+    - name: Install tools
+      run: python -m pip install --upgrade pip setuptools wheel twine
+    - name: Upload new release
+      env:
+        TWINE_USERNAME: '__token__'
+        TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+      run: python setup.py sdist bdist_wheel && twine upload --skip-existing dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+### 0.0.1 - 2022-03-10
+- Initial release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributor Guide
+
+Contributions welcome!  We'll expand this guide as we go.
+
+
+## Releasing a new version
+We want to ship bigfixes or new features as soon as they're ready,
+so our release process is automated:
+
+1. Increment `__version__` in `src/flake8_async.py`
+2. Ensure there's a corresponding entry in `CHANGELOG.md` with today's date
+3. Merge to master, and CI will do the rest!

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include *.md
+include LICENSE
+include tox.ini
+recursive-include tests *.py

--- a/flake8_async.py
+++ b/flake8_async.py
@@ -1,0 +1,43 @@
+"""A flake8 plugin that checks bad async / asyncio practices"""
+
+import ast
+from itertools import chain
+
+__version__ = "0.0.1"
+
+ASYNC100 = "ASYNC100: sync HTTP call in async function should use httpx.AsyncClient"
+
+
+class Visitor(ast.NodeVisitor):
+    PACKAGES = ("requests", "httpx")
+    METHODS = tuple("get options head post put patch delete request send".split())
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.errors = []  # list of (lineno, colno, message)
+
+    def visit_AsyncFunctionDef(self, node):
+        for inner in chain.from_iterable(map(ast.iter_child_nodes, node.body)):
+            if (
+                isinstance(inner, ast.Call)
+                and isinstance(inner.func, ast.Attribute)
+                and isinstance(inner.func.value, ast.Name)
+                and inner.func.value.id in self.PACKAGES
+                and inner.func.attr in self.METHODS
+            ):
+                self.errors.append((inner.lineno, inner.col_offset, ASYNC100))
+        self.generic_visit(node)
+
+
+class Plugin:
+    name = __name__
+    version = __version__
+
+    def __init__(self, tree: ast.AST) -> None:
+        self.tree = tree
+
+    def run(self):
+        visitor = Visitor()
+        visitor.visit(self.tree)
+        for line, col, msg in visitor.errors:
+            yield (line, col, msg, type(self))

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,48 @@
+"""Packaging config for Hypothesmith."""
+
+import os
+
+import setuptools
+
+
+def local_file(*name: str) -> str:
+    """Interpret filename as relative to this file."""
+    return os.path.relpath(os.path.join(os.path.dirname(__file__), *name))
+
+
+with open(local_file("flake8_async.py")) as o:
+    for line in o:
+        if line.startswith("__version__"):
+            _, __version__, _ = line.split('"')
+
+
+setuptools.setup(
+    name="flake8-async",
+    version=__version__,
+    author="Cooper Lees and Zac Hatfield-Dodds",
+    author_email="me@cooperlees.com",
+    py_modules=["flake8_async"],
+    url="https://github.com/cooperlees/flake8-async",
+    license="MIT",
+    description="A flake8 plugin that checks bad async / asyncio practices",
+    zip_safe=False,
+    install_requires=["flake8"],
+    python_requires=">=3.7",
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Framework :: Flake8",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+    ],
+    long_description=open(local_file("README.md")).read(),
+    long_description_content_type="text/markdown",
+    entry_points={
+        "flake8.extension": ["ASYNC = flake8_async:Plugin"],
+    },
+)

--- a/tests/test_changelog_and_version.py
+++ b/tests/test_changelog_and_version.py
@@ -1,0 +1,54 @@
+"""Tests for the hypothesmith package metadata."""
+import re
+from datetime import date
+from functools import lru_cache
+from pathlib import Path
+from typing import NamedTuple
+
+import flake8_async
+
+
+class Version(NamedTuple):
+    major: int
+    minor: int
+    patch: int
+
+    @classmethod
+    def from_string(cls, string):
+        return cls(*map(int, string.split(".")))
+
+
+@lru_cache()
+def get_releases():
+    pattern = re.compile(r"^### (\d+\.\d+\.\d+) - (\d\d\d\d-\d\d-\d\d)$")
+    with open(Path(__file__).parent.parent / "CHANGELOG.md") as f:
+        return tuple(
+            (Version.from_string(match.group(1)), match.group(2))
+            for match in map(pattern.match, f)
+            if match is not None
+        )
+
+
+def test_last_release_against_changelog():
+    last_version, last_date = get_releases()[0]
+    assert last_version == Version.from_string(flake8_async.__version__)
+    assert last_date <= date.today().isoformat()
+
+
+def test_changelog_is_ordered():
+    versions, dates = zip(*get_releases())
+    assert versions == tuple(sorted(versions, reverse=True))
+    assert dates == tuple(sorted(dates, reverse=True))
+
+
+def test_version_increments_are_correct():
+    # We either increment the patch version by one, increment the minor version
+    # and reset the patch, or increment major and reset both minor and patch.
+    versions, _ = zip(*get_releases())
+    for prev, current in zip(versions[1:], versions):
+        assert prev < current  # remember that `versions` is newest-first
+        assert current in (
+            prev._replace(patch=prev.patch + 1),
+            prev._replace(minor=prev.minor + 1, patch=0),
+            prev._replace(major=prev.major + 1, minor=0, patch=0),
+        ), f"{current} does not follow {prev}"

--- a/tests/test_flake8_async.py
+++ b/tests/test_flake8_async.py
@@ -1,0 +1,21 @@
+import ast
+
+import pytest
+
+from flake8_async import ASYNC100, Plugin
+
+
+@pytest.mark.parametrize(
+    "s,err",
+    [
+        ("", set()),
+        ("def f():\n    httpx.get('')\n", set()),
+        ("async def f():\n    a = 1\n    return a\n", set()),
+        (
+            "async def f():\n    httpx.get('')\n",
+            {(2, 4, ASYNC100, Plugin)},
+        ),
+    ],
+)
+def test_expected_results(s, err):
+    assert set(Plugin(ast.parse(s)).run()) == err

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,39 @@
+# The test environment and commands
+[tox]
+skipsdist = True
+
+[testenv:check]
+description = Runs all formatting tools then static analysis (quick)
+deps =
+    shed
+    flake8
+    flake8-builtins
+    flake8-bugbear
+    flake8-comprehensions
+commands =
+    shed
+    flake8
+
+[testenv:test]
+description = Runs pytest with posargs - `tox -e test -- -v` == `pytest -v`
+deps =
+    pytest
+    pytest-cov
+    # pytest-xdist
+commands =
+    pip install .
+    pytest  # {posargs:-n auto}
+
+
+# Settings for other tools
+[pytest]
+addopts =
+    -Werror
+    --tb=short
+    --cov=flake8_async
+    --cov-branch
+    --cov-report=term-missing:skip-covered
+    --cov-fail-under=100
+
+[flake8]
+ignore = E501,W503


### PR DESCRIPTION
I've set this up for automatic releases; you'll just need to issue a PyPI token and set it as the `TWINE_PASSWORD` repo secret.

The only trick there is that (until https://github.com/pypa/warehouse/issues/6378) for the first release, you'll need to use a full-user-scoped token, and then once the package exists you can replace that with a single-package-scoped release-only token.  The commands in `.github/workflows/ci.yml` should also be obvious if you want to run the first one locally instead.