### PR TITLE
ASYNC101: check for non-http blocking calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Future
+Add ASYNC101: blocking sync call in async function
+
 ## 22.3.10
 
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Future
+## 22.11.6
 Add ASYNC101: blocking sync call in async function
 
 ## 22.3.10

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ pip install git+https://github.com/cooperlees/flake8-async
 ## List of warnings
 
 - **ASYNC100**: Warning about the use of a blocking http call inside an `async def`
+- **ASYNC101**: Warning about the use of `open`, `time.sleep` or methods in `subprocess`, inside an `async def`.
 coroutine
 
 ## Development

--- a/flake8_async.py
+++ b/flake8_async.py
@@ -3,10 +3,10 @@
 import ast
 from itertools import chain
 
-__version__ = "22.3.10"
+__version__ = "22.11.6"
 
 ASYNC100 = "ASYNC100: sync HTTP call in async function should use httpx.AsyncClient"
-ASYNC101 = "ASYNC101: blocking sync call in async function"
+ASYNC101 = "ASYNC101: blocking sync call in async function, use framework equivalent"
 
 
 class Visitor(ast.NodeVisitor):

--- a/tests/test_flake8_async.py
+++ b/tests/test_flake8_async.py
@@ -2,7 +2,7 @@ import ast
 
 import pytest
 
-from flake8_async import ASYNC100, Plugin
+from flake8_async import ASYNC100, ASYNC101, Plugin
 
 
 @pytest.mark.parametrize(
@@ -14,6 +14,27 @@ from flake8_async import ASYNC100, Plugin
         (
             "async def f():\n    httpx.get('')\n",
             {(2, 4, ASYNC100, Plugin)},
+        ),
+        ("async def f():\n    time.time()\n", set()),
+        (
+            "async def f():\n    time.sleep(0)\n",
+            {(2, 4, ASYNC101, Plugin)},
+        ),
+        (
+            "async def f():\n    subprocess.foo(0)\n",
+            set(),
+        ),
+        (
+            "async def f():\n    subprocess.run(0)\n",
+            {(2, 4, ASYNC101, Plugin)},
+        ),
+        (
+            "async def f():\n    subprocess.call(0)\n",
+            {(2, 4, ASYNC101, Plugin)},
+        ),
+        (
+            "async def f():\n    open('foo')\n",
+            {(2, 4, ASYNC101, Plugin)},
         ),
     ],
 )


### PR DESCRIPTION
Itching in my fingers to restructure the code and take stuff from flake8-trio, but not worth it while the plugin is this small. Opted to create a new error code, though I bunched them up in the same parametrize in `test_flake8_async`.

handles `time.sleep`, `open`, and `subprocess.[run, Popen, call, check_call, check_output, getoutput, getstatusoutput]`.
The subprocess calls could be modified not to warn if `timeout=0`, and could do the same with `time.sleep(0)` - I don't know if those are acceptable or not.

fixes #4 

@Zac-HD 