### PR TITLE
fix invalid plugin code, exclude hidden files in tox flake8 check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,6 @@ setuptools.setup(
     ),
     long_description_content_type="text/markdown",
     entry_points={
-        "flake8.extension": ["ASYNC = flake8_async:Plugin"],
+        "flake8.extension": ["ASY = flake8_async:Plugin"],
     },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     flake8-comprehensions
 commands =
     shed
-    flake8
+    flake8 --exclude .*
 
 [testenv:test]
 description = Runs pytest with posargs - `tox -e test -- -v` == `pytest -v`


### PR DESCRIPTION
Trying to run flake8 with this plugin installed may trigger
```
$ flake8 --help                                                         
There was a critical error during execution of Flake8:
plugin code for `flake8-async[ASYNC]` does not match ^[A-Z]{1,3}[0-9]{0,3}$
```

Encountered the same thing in flake8-trio, solution is to modify the entry point in setup.py

--

My setup creates a `.virtualenv` folder in the same directory, so `tox -e check` runs on all dependencies. Could be fixed by using `pre-commit`, or I could solve it locally, but excluding `.*` in tox.ini is an easy fix in case anybody else would encounter the same.