### PR TITLE
Add os.wait* to ASYNC101 Add ASYNC102 for sync process call with os.popen, os.system, and os.*spawn*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## Future
+Add ASYNC102: probable blocking os call in async function
 
 ## 22.11.6
 Add ASYNC101: blocking sync call in async function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
-## Future
+
+## 22.11.14
 Add ASYNC102: probable blocking os call in async function
 
 ## 22.11.6

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip install git+https://github.com/cooperlees/flake8-async
 
 - **ASYNC100**: Warning about the use of a blocking http call inside an `async def`
 - **ASYNC101**: Warning about the use of `open`, `time.sleep` or methods in `subprocess`, inside an `async def`.
-coroutine
+- **ASYNC102**: Warning about the use of unsafe methods in `os` inside an `async def`.
 
 ## Development
 

--- a/flake8_async.py
+++ b/flake8_async.py
@@ -3,7 +3,7 @@
 import ast
 from itertools import chain
 
-__version__ = "22.11.6"
+__version__ = "22.11.14"
 
 ASYNC100 = "ASYNC100: sync HTTP call in async function should use httpx.AsyncClient"
 ASYNC101 = "ASYNC101: blocking sync call in async function, use framework equivalent"

--- a/tests/test_flake8_async.py
+++ b/tests/test_flake8_async.py
@@ -2,7 +2,7 @@ import ast
 
 import pytest
 
-from flake8_async import ASYNC100, ASYNC101, Plugin
+from flake8_async import ASYNC100, ASYNC101, ASYNC102, Plugin
 
 
 @pytest.mark.parametrize(
@@ -34,6 +34,18 @@ from flake8_async import ASYNC100, ASYNC101, Plugin
         ),
         (
             "async def f():\n    open('foo')\n",
+            {(2, 4, ASYNC101, Plugin)},
+        ),
+        (
+            "async def f():\n    os.fspath('foo')\n",
+            set(),
+        ),
+        (
+            "async def f():\n    os.popen(foo)\n",
+            {(2, 4, ASYNC102, Plugin)},
+        ),
+        (
+            "async def f():\n    os.wait(foo)\n",
             {(2, 4, ASYNC101, Plugin)},
         ),
     ],


### PR DESCRIPTION
I tried looking through the `os` methods and figure out which ones are bad to use in an async context, but that turned out trickier than I thought. There's probably a bunch of methods that are perfectly fine that just looks at data that python has cached, but best way I had of figuring that out was reading the description of them (which only worked in a few cases + there's a lot of them), or reading the source (which is more cumbersome when a bunch of them are implemented in c). If you have any good ideas on how too proceed @Zac-HD do let me know, or you can at least run it against your large codebases and find false positives before merging.