### PR TITLE
Test and release with Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools tox
@@ -28,12 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -48,9 +48,9 @@ jobs:
     needs: [check, test]
     if: github.repository == 'cooperlees/flake8-async' &&  github.ref == 'refs/heads/main'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
     - name: Install tools
       run: python -m pip install --upgrade build pip setuptools wheel twine
     - name: Upload new release

--- a/tests/test_changelog_and_version.py
+++ b/tests/test_changelog_and_version.py
@@ -1,4 +1,5 @@
 """Tests for the hypothesmith package metadata."""
+
 import re
 from pathlib import Path
 from typing import NamedTuple, Optional


### PR DESCRIPTION
This PR updates the CI config to:
* Run Tox **checks** with Python 3.12 (was 3.11)
* Run Tox **tests** with Python 3.12, in addition to the previous versions (3.7+)
* Updates `actions/checkout@v3` to `actions/checkout@v4`
* Updates `actions/setup-python@v3` and `actions/setup-python@v4` references to `actions/setup-python@v5`

P.S. - Thanks for creating this awesome flake8 plugin.